### PR TITLE
feat(chungthuang): Match user collection with platform-api user schema

### DIFF
--- a/extensions/users-permissions/models/User.settings.json
+++ b/extensions/users-permissions/models/User.settings.json
@@ -66,6 +66,26 @@
     "profile": {
       "model": "profile",
       "via": "user"
+    },
+    "discordId": {
+      "type": "string"
+    },
+    "googleId": {
+      "type": "string",
+      "required": true
+    },
+    "discordAvatar": {
+      "type": "string"
+    },
+    "discordDiscriminator": {
+      "type": "string"
+    },
+    "discordUsername": {
+      "type": "string"
+    },
+    "userId": {
+      "type": "uid",
+      "required": true
     }
   }
 }


### PR DESCRIPTION
This PR aligns user model in https://github.com/dev-launchers/platform__api/blob/main/models/user.js with user collection in strapi. Strapi already defines username in the collection. Strapi doesn't neither supports UUID nor changing primary key. For now we have to model UUID as Strapi UID with an unique constraint in Postgres.