### PR TITLE
fix(alearm246): set domain attribute specifically to subdomain

### DIFF
--- a/api/custom/controllers/custom.js
+++ b/api/custom/controllers/custom.js
@@ -10,6 +10,13 @@ module.exports = {
         maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
         domain: 'localhost'
       });
+    } else if(process.env.NODE_ENV === 'staging') {
+      ctx.cookies.set('token', null, {
+        httpOnly: true,
+        secure: true,
+        maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
+        domain: 'staging.devlaunchers.com'
+      });
     }
     else {
       ctx.cookies.set('token', null, {

--- a/api/custom/controllers/custom.js
+++ b/api/custom/controllers/custom.js
@@ -10,20 +10,13 @@ module.exports = {
         maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
         domain: 'localhost'
       });
-    } else if(process.env.NODE_ENV === 'staging') {
-      ctx.cookies.set('token', null, {
-        httpOnly: true,
-        secure: true,
-        maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
-        domain: 'staging.devlaunchers.com'
-      });
     }
     else {
       ctx.cookies.set('token', null, {
         httpOnly: true,
         secure: true,
         maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
-        domain: 'devlaunchers.com'
+        domain: process.env.DOMAIN
       });
     }
 

--- a/extensions/users-permissions/controllers/Auth.js
+++ b/extensions/users-permissions/controllers/Auth.js
@@ -214,7 +214,7 @@ module.exports = {
           domain: 'staging.devlaunchers.com'
         });
       }
-       else {
+      else {
         ctx.cookies.set('token', token, {
           httpOnly: true,
           secure: true,

--- a/extensions/users-permissions/controllers/Auth.js
+++ b/extensions/users-permissions/controllers/Auth.js
@@ -206,20 +206,13 @@ module.exports = {
           maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
           domain: 'localhost'
         });
-      } else if(process.env.NODE_ENV === 'staging') {
-        ctx.cookies.set('token', token, {
-          httpOnly: true,
-          secure: true,
-          maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
-          domain: 'staging.devlaunchers.com'
-        });
       }
       else {
         ctx.cookies.set('token', token, {
           httpOnly: true,
           secure: true,
           maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
-          domain: 'devlaunchers.com'
+          domain: process.env.DOMAIN
         });
       }
 

--- a/extensions/users-permissions/controllers/Auth.js
+++ b/extensions/users-permissions/controllers/Auth.js
@@ -206,7 +206,15 @@ module.exports = {
           maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
           domain: 'localhost'
         });
-      } else {
+      } else if(process.env.NODE_ENV === 'staging') {
+        ctx.cookies.set('token', token, {
+          httpOnly: true,
+          secure: true,
+          maxAge: 1000 * 60 * 60 * 24 * 14, // 14 Day Age,
+          domain: 'staging.devlaunchers.com'
+        });
+      }
+       else {
         ctx.cookies.set('token', token, {
           httpOnly: true,
           secure: true,

--- a/production/configmap.yaml
+++ b/production/configmap.yaml
@@ -7,4 +7,4 @@ data:
   frontend_url: "https://devlaunchers.com"
   node_env: "production"
   redirect_url: "https://cms-api.devlaunchers.com/auth/discord/redirect"
-  
+  domain: "devlaunchers.com"

--- a/staging/configmap.yaml
+++ b/staging/configmap.yaml
@@ -7,3 +7,4 @@ data:
   frontend_url: "https://staging.devlaunchers.com"
   node_env: "staging"
   redirect_url: "https://cms-api-staging.devlaunchers.com/auth/discord/redirect"
+  domain: "staging.devlaunchers.com"

--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -122,6 +122,11 @@ spec:
             configMapKeyRef:
               name: strapi-config
               key: node_env
+        - name: DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              name: strapi-config
+              key: domain
         - name: STRAPI_LOG_LEVEL
           value: info
         - name: AUDIT_FREQ_MINUTES


### PR DESCRIPTION
I set the domain attribute for the HTTP only cookie specifically to the staging.devlaunchers.com subdomain only on the staging server to only let the cookie be shared with that subdomain. This will hopefully fix signup up issue on the staging server.