### PR TITLE
Revert "ops(chungthuang): Mount license file"

### DIFF
--- a/staging/kservice.yaml
+++ b/staging/kservice.yaml
@@ -13,12 +13,6 @@ spec:
             items:
             - key: google-service-key.json
               path: google-service-key.json
-        - name: license
-          secret:
-            secretName: license
-            items:
-            - key: license.txt
-              path: license.txt
       containers:
       - name: strapi
         image: devlaunchers/cms-api:190e6cd-202201292107
@@ -151,5 +145,3 @@ spec:
         volumeMounts:
         - name: google-directory-key
           mountPath: "/etc/google-directory"
-        - name: license
-          mountPath: /srv/app

--- a/workload/deployment.yaml
+++ b/workload/deployment.yaml
@@ -22,12 +22,6 @@ spec:
             items:
             - key: google-service-key.json
               path: google-service-key.json
-        - name: license
-          secret:
-            secretName: license
-            items:
-            - key: license.txt
-              path: license.txt
       containers:
       - name: strapi
         image: devlaunchers/cms-api:latest
@@ -160,8 +154,6 @@ spec:
         volumeMounts:
         - name: google-directory-key
           mountPath: "/etc/google-directory"
-        - name: license
-          mountPath: /srv/app
         resources:
           limits:
             cpu: 128m


### PR DESCRIPTION
Mounting the license file overwrote the app files
```
enoent ENOENT: no such file or directory, open '/srv/app/package.json'
```