### PR TITLE
feat(pyxld-kris): Add redirect URL param in auth flow

### DIFF
--- a/extensions/users-permissions/controllers/Auth.js
+++ b/extensions/users-permissions/controllers/Auth.js
@@ -216,7 +216,9 @@ module.exports = {
         });
       }
 
-      if(!user.username){
+      if (ctx.session.grant.dynamic.redirectUrl) {
+        ctx.redirect(ctx.session.grant.dynamic.redirectUrl);
+      } else if(!user.username) {
         ctx.redirect(`${process.env.FRONTEND_URL}/signup`);
       } else {
         ctx.redirect(`${process.env.FRONTEND_URL}/users/me`);

--- a/extensions/users-permissions/controllers/Auth.js
+++ b/extensions/users-permissions/controllers/Auth.js
@@ -216,8 +216,8 @@ module.exports = {
         });
       }
 
-      if (ctx.session.grant.dynamic.redirectUrl) {
-        ctx.redirect(ctx.session.grant.dynamic.redirectUrl);
+      if (ctx.session.grant.dynamic.redirectURL) {
+        ctx.redirect(ctx.session.grant.dynamic.redirectURL);
       } else if(!user.username) {
         ctx.redirect(`${process.env.FRONTEND_URL}/signup`);
       } else {


### PR DESCRIPTION
This PR adds the ability for the login route (`/connect/google`) to accept a `redirectURL` GET parameter, which defines a URL the user will be redirected to after authenticating with Google. If not set, the user will be redirected to the User Profile/Signup page (the previous behavior). 