### PR TITLE
fix(pyxld-kris): Fix User model hook

### DIFF
--- a/extensions/users-permissions/models/User.js
+++ b/extensions/users-permissions/models/User.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 module.exports = {
   /**
@@ -7,7 +7,7 @@ module.exports = {
   lifecycles: {
     async beforeUpdate(params, data) {
       if (data.username)
-        data.username = data.username.trim().replace(/\s+/g, "_");
+        data.username = data.username.trim().replace(/\s+/g, '_');
     },
   },
 };

--- a/extensions/users-permissions/models/User.js
+++ b/extensions/users-permissions/models/User.js
@@ -1,12 +1,13 @@
-'use strict';
+"use strict";
 
 module.exports = {
   /**
-  * Triggered before user creation.
-  */
-  lifecycles:{
-    async beforeUpdate(params, data)  {
-      data.username=data.username.trim().replace(/\s+/g,'_');
+   * Triggered before user creation.
+   */
+  lifecycles: {
+    async beforeUpdate(params, data) {
+      if (data.username)
+        data.username = data.username.trim().replace(/\s+/g, "_");
     },
   },
 };


### PR DESCRIPTION
Currently, when partial updates are performed on the User model which do not unclude the `username` attribute, the hook tries to access a nonexistant attribute on the incoming data.
This causes an error and prevents any other attributes from being updated.
This commit checks whether or not that data exists in the incoming change, and if not excludes the check which allows the User model to be partially updated.